### PR TITLE
Consume: Changes to cancellation token usage

### DIFF
--- a/Frends.Community.ActiveMQ/ActiveMQTasks.cs
+++ b/Frends.Community.ActiveMQ/ActiveMQTasks.cs
@@ -36,8 +36,8 @@ namespace Frends.Community.ActiveMQ
                         cancellationToken.ThrowIfCancellationRequested();
                         readNextMessage = false;
                         
-                        var task = Task.Run(() => consumer.Receive());
-                        if (task.Wait(TimeSpan.FromSeconds(5)))
+                        var task = Task.Run(() => consumer.Receive(TimeSpan.FromSeconds(options.Timeout)), cancellationToken);
+                        if (task.Wait(5000, cancellationToken))
                         {
                             if (task.Result is ITextMessage textMessage)
                             {
@@ -63,7 +63,12 @@ namespace Frends.Community.ActiveMQ
                             {
                                 messages.Add(new Message("Object", "Object messages are not supported"));
                                 readNextMessage = true;
-                            } else {
+                            }
+                            else if (task.Result is null)
+                            {
+                                break;
+                            }
+                            else {
                                 messages.Add(new Message("Unknown message type", "Unknown message type: " + task.Result.GetType().Name));
                             }
                             

--- a/Frends.Community.ActiveMQ/Definitions.cs
+++ b/Frends.Community.ActiveMQ/Definitions.cs
@@ -27,6 +27,12 @@ namespace Frends.Community.ActiveMQ
     public class Options
     {
         /// <summary>
+        /// Timeout for receiving messages. Timeout affects to single message.
+        /// </summary>
+        [DefaultValue(10)]
+        public int Timeout { get; set; }
+
+        /// <summary>
         /// Maximum number of messages to receive. 0 means no limit.
         /// </summary>
         [DefaultValue(0)]

--- a/Frends.Community.ActiveMQ/Frends.Community.ActiveMQ.csproj
+++ b/Frends.Community.ActiveMQ/Frends.Community.ActiveMQ.csproj
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 2.0.0   | Initial implementation of Produce-Task, Documentation fix for Consume-Task.                                                                |
 | 3.0.0   | Consume: result's Messages property changed from array of strings to Message { string Type, dynamic Message }; added byte message support. |
 | 3.1.0   | Consume: Added MaxMessagesToConsume parameter to Options                                                                                   |
+| 3.2.0   | Consume: Added Timeout parameter for single message and added cancellation tokens to Task.Run and Task.Wait methods.                       |


### PR DESCRIPTION
#12 
Consume: Added Timeout parameter for single message and added cancellation tokens to Task.Run and Task.Wait methods.  